### PR TITLE
Add CLI that copies data between SQL Server tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bulklet Demo Spring Boot Project
 
-This repository contains a minimal Maven-based Spring Boot application. The project includes the Microsoft SQL Server JDBC driver as a dependency.
+This repository contains a minimal Spring Boot command-line application. The project includes the Microsoft SQL Server JDBC driver as a dependency and demonstrates copying data between two tables using the SQL Server bulk API.
 
 ## Building and Running
 
@@ -17,6 +17,8 @@ After Maven is available, build the project with:
 ```bash
 mvn package
 ```
+
+Before running the application, ensure a SQL Server instance is accessible at `localhost` using the credentials `sa` / `YourStrongPassword123`.
 
 To start the application, run:
 

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,11 +1,50 @@
 package com.example.demo;
 
+import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
 @SpringBootApplication
-public class DemoApplication {
+public class DemoApplication implements CommandLineRunner {
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        String url = "jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true";
+        Properties props = new Properties();
+        props.put("user", "sa");
+        props.put("password", "YourStrongPassword123");
+
+        try (Connection sourceConn = DriverManager.getConnection(url, props);
+             Connection targetConn = DriverManager.getConnection(url, props)) {
+
+            try (Statement stmt = sourceConn.createStatement()) {
+                stmt.executeUpdate("IF OBJECT_ID('quelle', 'U') IS NOT NULL DROP TABLE quelle");
+                stmt.executeUpdate("CREATE TABLE quelle (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))");
+                stmt.executeUpdate("INSERT INTO quelle (name) VALUES ('Alice'), ('Bob'), ('Charlie')");
+            }
+
+            try (Statement stmt = targetConn.createStatement()) {
+                stmt.executeUpdate("IF OBJECT_ID('ziel', 'U') IS NOT NULL DROP TABLE ziel");
+                stmt.executeUpdate("CREATE TABLE ziel (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(100))");
+            }
+
+            try (Statement stmt = sourceConn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT id, name FROM quelle")) {
+                SQLServerBulkCopy bulkCopy = new SQLServerBulkCopy(targetConn);
+                bulkCopy.setDestinationTableName("ziel");
+                bulkCopy.writeToServer(rs);
+                bulkCopy.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement a Spring Boot command-line application that connects twice to a local SQL Server instance
- create example table `quelle` with sample data
- create table `ziel` and import data using `SQLServerBulkCopy`
- document SQL Server requirement in the README

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd8d35b0832c9b9c276d887abca1