### PR TITLE
Add mocked JDBC test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -28,6 +28,16 @@ public class DemoApplication implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+        executeSqlTasks();
+        int exitCode = SpringApplication.exit(context);
+        System.exit(exitCode);
+    }
+
+    /**
+     * Executes all SQL tasks used by the demo application. Extracted for easier
+     * testing.
+     */
+    void executeSqlTasks() throws Exception {
         String url = "jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true";
         Properties props = new Properties();
         props.put("user", "sa");
@@ -58,9 +68,7 @@ public class DemoApplication implements CommandLineRunner {
                 bulkCopy.writeToServer(rs);
                 bulkCopy.close();
             }
-            log.info("SQL tasks completed, shutting down");
-            int exitCode = SpringApplication.exit(context);
-            System.exit(exitCode);
+            log.info("SQL tasks completed");
         }
     }
 }

--- a/src/test/java/com/example/demo/DemoApplicationTest.java
+++ b/src/test/java/com/example/demo/DemoApplicationTest.java
@@ -1,0 +1,57 @@
+package com.example.demo;
+
+import com.microsoft.sqlserver.jdbc.SQLServerBulkCopy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DemoApplicationTest {
+
+    @Test
+    void executeSqlTasksUsesJdbcCalls() throws Exception {
+        DemoApplication app = new DemoApplication();
+        ConfigurableApplicationContext ctx = mock(ConfigurableApplicationContext.class);
+        ReflectionTestUtils.setField(app, "context", ctx);
+
+        Connection sourceConn = mock(Connection.class);
+        Connection targetConn = mock(Connection.class);
+        Statement sourceStmt1 = mock(Statement.class);
+        Statement sourceStmt2 = mock(Statement.class);
+        Statement targetStmt = mock(Statement.class);
+        ResultSet rs = mock(ResultSet.class);
+
+        when(sourceConn.createStatement()).thenReturn(sourceStmt1, sourceStmt2);
+        when(targetConn.createStatement()).thenReturn(targetStmt);
+        when(sourceStmt2.executeQuery("SELECT id, name FROM quelle")).thenReturn(rs);
+
+        try (MockedStatic<DriverManager> dm = mockStatic(DriverManager.class);
+             MockedConstruction<SQLServerBulkCopy> bulkConst = mockConstruction(SQLServerBulkCopy.class)) {
+            dm.when(() -> DriverManager.getConnection(anyString(), any(Properties.class)))
+              .thenReturn(sourceConn, targetConn);
+
+            app.executeSqlTasks();
+
+            dm.verify(() -> DriverManager.getConnection(anyString(), any(Properties.class)), times(2));
+            verify(targetStmt).executeUpdate(contains("CREATE TABLE ziel"));
+            SQLServerBulkCopy bulkCopy = bulkConst.constructed().get(0);
+            verify(bulkCopy).setDestinationTableName("ziel");
+            verify(bulkCopy).writeToServer(rs);
+            verify(bulkCopy).close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract JDBC logic into `executeSqlTasks` for testability
- add Mockito-inline dependency
- create `DemoApplicationTest` using static and construction mocking

## Testing
- `mvn -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -q package`

------
https://chatgpt.com/codex/tasks/task_e_684ec1f6a52c832ca6aa3b89ff3de77d